### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,5 @@
     "vinyl-ftp": "^0.5.0",
     "wowjs": "^1.1.3"
   },
-  "dependencies": {
-    "npm": "^6.1.0"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION

Hello akjeres!

It seems like you have npm as one of your (dev-) dependency in sumer-internship.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
